### PR TITLE
force the composer git version to be an array

### DIFF
--- a/modules/platform_composer_git/hosting_platform_composer_git.features.field_instance.inc
+++ b/modules/platform_composer_git/hosting_platform_composer_git.features.field_instance.inc
@@ -133,7 +133,11 @@ function hosting_platform_composer_git_field_default_field_instances() {
   // Exported field_instance: 'node-platform-field_composer_git_version'.
   $field_instances['node-platform-field_composer_git_version'] = array(
     'bundle' => 'platform',
-    'default_value' => 'master',
+      'default_value' => array(
+          0 => array(
+              'value' => 'master',
+          ),
+      ),
     'deleted' => 0,
     'description' => 'Optionally specify a Git branch or tag. Defaults to the `master` branch.',
     'display' => array(


### PR DESCRIPTION
I'm attempting to run Aegir without BOA but using, all Omega8 forks.   One issue that occurs, is I'm getting this error constantly:

` 03/Nov 01:55  php       error     TypeError: count(): Argument #1 ($value) must be of type Countable|array, string given in field_default_form() (line 77 of /var/aegir/hostmaster-7.x-3.x/modules/field/field.form.inc).`

Which appears to track back to setting the default value of the branch to master, flipping it to an array works.